### PR TITLE
fix: traverse scopes to find the variable definition in avoid-injections

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ In your eslint config file:
 ### `knex/avoid-injections`
 
 Avoid some of the more obvious issues when it comes to SQL injection. This rule disallows any kind of interpolated string as the first argument to `.raw()`, `.whereRaw`, and `.joinRaw`.
+
+## Development
+
+Here's a good starting point for working with the rule in ASTExplorer:
+
+https://astexplorer.net/#/gist/01bce73cb93c30d0a83fdc1502c129c9/2ac43132c3bbdf9ada9dcc26a55fae33bfbc2085

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prettier": "^2.2.1"
   },
   "prettier": {
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "arrowParens": "avoid"
   }
 }

--- a/rules/avoid-injections.test.js
+++ b/rules/avoid-injections.test.js
@@ -3,10 +3,10 @@ const rule = require("./avoid-injections");
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
 
-function invalidCase(code, errorIds = []) {
+function invalidCase(code, errors = []) {
   return {
     code,
-    errors: errorIds.map((id) => ({ messageId: id })),
+    errors,
   };
 }
 
@@ -17,29 +17,47 @@ ruleTester.run("avoid-injections", rule, {
     "knex.raw(`select * from users`)",
     "knex.raw('select ? from users', ['email'])",
     `const query = 'SELECT * FROM users'; const result = knex.raw(query);`,
-
+    `
+    const query = \`now() + interval '123 seconds'\`;
+    function run() {
+      return knex.raw(query);
+    }
+    `,
     "knex('users').whereRaw('id = ?', [1]);",
     "knex('users').whereRaw(`id = 1`);",
-
     "const joinCondition = `blog_posts ON users.id = blog_posts.author`; knex('users').select(['email']).joinRaw(joinCondition)",
   ],
   invalid: [
-    invalidCase("knex.raw(`select * from ${table}`);", ["avoid-raw"]),
-    invalidCase('knex.raw("select * from " + table);', ["avoid-raw"]),
+    // .raw()
+    invalidCase("knex.raw(`select * from ${table}`);", [
+      { messageId: "avoid", data: { query: "raw" } },
+    ]),
+    invalidCase('knex.raw("select * from " + table);', [
+      { messageId: "avoid", data: { query: "raw" } },
+    ]),
+    invalidCase(
+      "const email = 'user@domain.com'; const query = `SELECT * FROM users WHERE email='${email}'`; function run() { knex.raw(query); }",
+      [{ messageId: "avoid", data: { query: "raw" } }],
+    ),
 
-    invalidCase("knex('users').whereRaw(`id = ${id}`);", ["avoid-whereraw"]),
-    invalidCase("knex('users').whereRaw(`id = ` + id);", ["avoid-whereraw"]),
+    // .whereRaw()
+    invalidCase("knex('users').whereRaw(`id = ${id}`);", [
+      { messageId: "avoid", data: { query: "whereRaw" } },
+    ]),
+    invalidCase("knex('users').whereRaw(`id = ` + id);", [
+      { messageId: "avoid", data: { query: "whereRaw" } },
+    ]),
     invalidCase("knex('users').whereRaw(`id = ${getId()}`);", [
-      "avoid-whereraw",
+      { messageId: "avoid", data: { query: "whereRaw" } },
+    ]),
+    invalidCase("knex('users').whereRaw(`id = ${getId()}`);", [
+      { messageId: "avoid" },
     ]),
 
-    invalidCase("knex('users').whereRaw(`id = ${getId()}`);", [
-      "avoid-whereraw",
-    ]),
-
+    // .joinRaw()
     invalidCase(
       "knex('users').select(['email']).joinRaw(`blog_posts ON users.id = ${userId}`)",
-      ["avoid-joinraw"],
+      [{ messageId: "avoid", data: { query: "joinRaw" } }],
     ),
   ],
 });


### PR DESCRIPTION
Fixes #1 