### PR TITLE
feat: config a builder name pattern in settings to avoid irrelevant cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ In your eslint config file:
 }
 ```
 
+## Settings
+
+You can configure what names you intend to use for the knex client. Make sure to
+include the library itself (`knex`), but also transaction variables (`trx`,
+`transaction`).
+
+```
+{
+  "settings": {
+    "knex": {
+      "builderName": "^(knex|transaction)$"
+    }
+  }
+}
+```
+
 ## Rules
 
 ### `knex/avoid-injections`

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^7.0.0",
+    "eslint-remote-tester": "^1.1.0",
     "jest": "^26.6.3",
     "prettier": "^2.2.1"
   },

--- a/rules/avoid-injections.js
+++ b/rules/avoid-injections.js
@@ -16,6 +16,19 @@ module.exports = {
       [`CallExpression[callee.property.name=${rawStatements}][arguments.0.type!='Literal']`](
         node,
       ) {
+        if (context.settings && context.settings.knex) {
+          const builder = node.callee.object;
+          const builderName = builder.name || builder.callee.name;
+          const { builderName: builderNamePattern } = context.settings.knex;
+
+          if (
+            builderNamePattern instanceof RegExp &&
+            !builderNamePattern.test(builderName)
+          ) {
+            return;
+          }
+        }
+
         check(context, node);
       },
     };

--- a/rules/avoid-injections.test.js
+++ b/rules/avoid-injections.test.js
@@ -1,40 +1,44 @@
 const { RuleTester } = require("eslint");
 const rule = require("./avoid-injections");
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
-
-function invalidCase(code, errors = []) {
-  return {
-    code,
-    errors,
-  };
+function invalidCase(code, errors = [], others = {}) {
+  return Object.assign(
+    {
+      code,
+      errors,
+    },
+    others,
+  );
 }
 
-ruleTester.run("avoid-injections", rule, {
+const tester = new RuleTester({
+  parserOptions: { ecmaVersion: 2015 },
+});
+
+tester.run("avoid-injections", rule, {
   valid: [
     "knex.raw('select ? from users', ['email'])",
-    "knex.raw('select * from users');",
     "knex.raw(`select * from users`)",
     "knex.raw('select ? from users', ['email'])",
     `const query = 'SELECT * FROM users'; const result = knex.raw(query);`,
     `
     const query = \`now() + interval '123 seconds'\`;
     function run() {
-      return knex.raw(query);
+    return knex.raw(query);
     }
     `,
     "knex('users').whereRaw('id = ?', [1]);",
     "knex('users').whereRaw(`id = 1`);",
     "const joinCondition = `blog_posts ON users.id = blog_posts.author`; knex('users').select(['email']).joinRaw(joinCondition)",
-    `
-    function sharp() {
-      return {
-        raw: () => {},
-      };
-    }
-    sharp().raw();
-    `,
-    "page.drawText(`${foo}bar`);",
+    `function sharp() { return { raw: () => {}, }; } sharp().raw();`,
+    {
+      code: "knex('users').whereRaw(`id = ` + id);",
+      settings: {
+        knex: {
+          builderName: /(transaction|trx)/i,
+        },
+      },
+    },
   ],
   invalid: [
     // .raw()
@@ -67,6 +71,18 @@ ruleTester.run("avoid-injections", rule, {
     invalidCase(
       "knex('users').select(['email']).joinRaw(`blog_posts ON users.id = ${userId}`)",
       [{ messageId: "avoid", data: { query: "joinRaw" } }],
+    ),
+
+    invalidCase(
+      "lorem.raw(`select * from ${table}`);",
+      [{ messageId: "avoid", data: { query: "raw" } }],
+      {
+        settings: {
+          knex: {
+            builderName: /lorem/i,
+          },
+        },
+      },
     ),
   ],
 });


### PR DESCRIPTION
This adress the problem seen in #7. By specifying a regex pattern for what builders will be named, any false negatives and/or positives can be avoided.

The idea is to configure eslint something like this:

```javascript
{
  settings: {
    knex: {
      builderName: /(knex|transaction|trx)/i
    }      
  }
}
```