### PR TITLE
fix: exit early if query variable is a parameter

### DIFF
--- a/rules/avoid-injections.js
+++ b/rules/avoid-injections.js
@@ -63,6 +63,8 @@ function check(context, node) {
     // The input variable is not defined?
     if (!variableDefinition) return;
 
+    if (variableDefinition.defs[0].type === "Parameter") return;
+
     const queryVariableDefinition = variableDefinition.defs[0].node;
 
     if (

--- a/rules/avoid-injections.test.js
+++ b/rules/avoid-injections.test.js
@@ -29,6 +29,8 @@ tester.run("avoid-injections", rule, {
     `,
     "knex('users').whereRaw('id = ?', [1]);",
     "knex('users').whereRaw(`id = 1`);",
+    "const wrapQuery = (query, args) => knex.raw(query, args);",
+    "function wrapQuery(query, args) { return knex.raw(query, args); }",
     "const joinCondition = `blog_posts ON users.id = blog_posts.author`; knex('users').select(['email']).joinRaw(joinCondition)",
     `function sharp() { return { raw: () => {}, }; } sharp().raw();`,
     {


### PR DESCRIPTION
For parameters we shouldn't check for `.init` as it won't be defined.
Currently using `knex.raw` inside of function or arrow function will crash eslint if `query` came from parameter.

This PR fixes this issue.