### PR TITLE
feat: make rawStatements user-configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ include the library itself (`knex`), but also transaction variables (`trx`,
 {
   "settings": {
     "knex": {
+      "rawStatements": "^(raw|whereRaw|joinRaw)$",
       "builderName": "^(knex|transaction)$"
     }
   }

--- a/rules/avoid-injections.js
+++ b/rules/avoid-injections.js
@@ -10,16 +10,29 @@ module.exports = {
   },
 
   create(context) {
-    const rawStatements = /^(raw|whereRaw|joinRaw)$/;
+    const options = {
+      rawStatements: /^(raw|whereRaw|joinRaw)$/,
+      builderNamePattern: null,
+    };
+
+    if (context.settings && context.settings.knex) {
+      const {
+        rawStatements,
+        builderName: builderNamePattern,
+      } = context.settings.knex;
+
+      if (rawStatements) options.rawStatements = rawStatements;
+      if (builderNamePattern) options.builderNamePattern = builderNamePattern;
+    }
 
     return {
-      [`CallExpression[callee.property.name=${rawStatements}][arguments.0.type!='Literal']`](
+      [`CallExpression[callee.property.name=${options.rawStatements}][arguments.0.type!='Literal']`](
         node,
       ) {
-        if (context.settings && context.settings.knex) {
+        const { builderNamePattern } = options;
+        if (builderNamePattern) {
           const builder = node.callee.object;
           const builderName = builder.name || builder.callee.name;
-          const { builderName: builderNamePattern } = context.settings.knex;
 
           if (
             builderNamePattern instanceof RegExp &&

--- a/rules/avoid-injections.test.js
+++ b/rules/avoid-injections.test.js
@@ -84,5 +84,17 @@ tester.run("avoid-injections", rule, {
         },
       },
     ),
+
+    invalidCase(
+      'db.wrapQuery("select * from " + table, null);',
+      [{ messageId: "avoid", data: { query: "wrapQuery" } }],
+      {
+        settings: {
+          knex: {
+            rawStatements: /^(raw|whereRaw|joinRaw|wrapQuery)$/,
+          },
+        },
+      },
+    ),
   ],
 });


### PR DESCRIPTION
In some cases knex might be used through a helper function
that uses different name than any of predefined ones (raw, joinRaw,
whereRaw).

In this case allowing users to add different function names can be
useful.

For example
```js
db.wrapQuery = (query) => (...args) => knex.query(query, args)

const getUserById = db.wrapQuery('select * from ' + table + ' where id = ?')
```